### PR TITLE
Grd 818: Adding a Copy Out task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,14 @@
-## 1.0.0 - 2024-06-25
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [1.1.0] - 2024-09-24
+### Changed
+[GRD-818](https://jira.oicr.on.ca/browse/GRD-818) - modify bamToFastq.wdl to include a copy out task
+
+## [1.0.0] - 2024-06-25
+### Changed
 [GRD-797](https://jira.oicr.on.ca/browse/GRD-797) - add vidarr labels to outputs (changes to medata only)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Generating R1 and R2 from bam files
 ## Dependencies
 
 * [java 8](https://www.java.com/en/download/manual.jsp)
-* [samtools 1.9](https://github.com/samtools/samtools/archive/0.1.19.tar.gz)
+* [samtools 1.14](https://github.com/samtools/samtools/archive/0.1.19.tar.gz)
 * [picard 2.21.2](https://broadinstitute.github.io/picard/command-line-overview.html)
 * [python 3.6](https://www.python.org/downloads/)
 
@@ -32,6 +32,7 @@ Parameter|Value|Description
 #### Optional workflow parameters:
 Parameter|Value|Default|Description
 ---|---|---|---
+`finalOutputDirectory`|String|""|Optional final output directory. Copy out fastq files using a task
 
 
 #### Optional task parameters:
@@ -40,55 +41,65 @@ Parameter|Value|Default|Description
 `countFlags.prefix`|String|"output"|String prepended to flagstat file
 `countFlags.memory`|Int|24|Memory allocated for this job
 `countFlags.timeout`|Int|12|Time in hours before task timeout
-`countFlags.modules`|String|"samtools/0.1.19"|Required environment modules
-`nameCheck.modules`|String|""|Required environment modules
+`countFlags.modules`|String|"samtools/1.14"|Required environment modules
 `nameCheck.memory`|Int|24|Memory allocated for this job
 `nameCheck.timeout`|Int|12|Time in hours before task timeout
 `backExtract.modules`|String|"picard/2.21.2"|Required environment modules
 `backExtract.memory`|Int|24|Memory allocated for this job
 `backExtract.timeout`|Int|12|Time in hours before task timeout
-`renameFastqs.modules`|String|""|Required environment modules
-`renameFastqs.memory`|Int|24|Memory allocated for this job
-`renameFastqs.timeout`|Int|12|Time in hours before task timeout
+`haveCustomDirRename.modules`|String|""|Required environment modules
+`haveCustomDirRename.memory`|Int|24|Memory allocated for this job
+`haveCustomDirRename.timeout`|Int|12|Time in hours before task timeout
+`copyOutFastq.memory`|Int|24|Memory allocated for this job
+`copyOutFastq.timeout`|Int|12|Time in hours before task timeout
+`composeLog.memory`|Int|4|Memory allocated for this job
+`composeLog.timeout`|Int|2|Time in hours before task timeout
+`noCustomDirRename.modules`|String|""|Required environment modules
+`noCustomDirRename.memory`|Int|24|Memory allocated for this job
+`noCustomDirRename.timeout`|Int|12|Time in hours before task timeout
 
 
 ### Outputs
 
 Output | Type | Description | Labels
 ---|---|---|---
-`flagStat`|File|A TXT file containing flag information about the BAM file|
-`modFastqs`|Array[File]?|FASTQs renamed in accordance to input|
+`flagStat`|File|A TXT file containing flag information about the BAM file|vidarr_label: flagStat
+`modFastqs`|Array[File]?|An optional array of fastq.gz files|vidarr_label: modFastqs
+`copyLog`|File?|log file from copy out task, provisioned if a custom output dir requested|vidarr_label: copyLog
 
 
 ## Commands
- This section lists command(s) run by bamToFastq workflow
  
- * Running bamToFastq
+This section lists command(s) run by bamToFastq workflow
  
- bamToFastq generates R1 and R2 fastqs for BAM files with one or more readgroups.
+* Running bamToFastq
  
- ### Pulling out readgroups and flag data from bam file
- ```
-             module load samtools
-             samtools flagstat ~{bamFile} > ~{prefix}.flagstat.txt
-             samtools view -H ~{bamFile} | grep -G "^@RG" > readgroups.tsv
- ```
+bamToFastq generates R1 and R2 fastqs for BAM files with one or more readgroups.
  
- ### Checking name validity and creating new filenames.
- By default, the fastqs are named using the read IDs. To use RG tags in the file names of the generated fastqs, input paramenter filNaming should be formatted like this:
+### Pulling out readgroups and flag data from bam file
  
- ```
+```
+     module load samtools
+     samtools flagstat ~{bamFile} > ~{prefix}.flagstat.txt
+     samtools view -H ~{bamFile} | grep -G "^@RG" > readgroups.tsv
+```
+ 
+### Checking name validity and creating new filenames.
+ 
+By default, the fastqs are named using the read IDs. To use RG tags in the file names of the generated fastqs, input paramenter filNaming should be formatted like this:
+ 
+```
  "{tag1}_{tag2}"
  "{PU}_{PL}"
  "{LB}_{PU}_test01"
- ```
- (fileNaming follows Python 3.9 string-mapping formatting)
+```
+(fileNaming follows Python 3.9 string-mapping formatting)
  
- The file naming scheme will be declared invalid if:
+The file naming scheme will be declared invalid if:
  - It results in non-unique file names
  - It contains an invalid RG tag
- ```
  
+```
          python3<<CODE
  
          import difflib
@@ -158,47 +169,74 @@ Output | Type | Description | Labels
          
          CODE
  
- ```
- ### Backextract fastq files from bam file per readgroup.
- ```
-             module unload cromwell ## <- only needed for local testing
-             module unload java ## <- only needed for local testing
-             module load picard
+```
+### Backextract fastq files from bam file per readgroup.
  
-             java -Xmx20g -jar $PICARD_ROOT/picard.jar SamToFastq \
-             INPUT=~{bamFile} \
-             RG_TAG="ID" \
-             OUTPUT_DIR=. \
-             OUTPUT_PER_RG=true \
-             NON_PF=true \
-             RE_REVERSE=true \
-             VALIDATION_STRINGENCY=LENIENT
+```
+     java -Xmx20g -jar $PICARD_ROOT/picard.jar SamToFastq \
+     INPUT=~{bamFile} \
+     RG_TAG="ID" \
+     OUTPUT_DIR=. \
+     OUTPUT_PER_RG=true \
+     NON_PF=true \
+     RE_REVERSE=true \
+     VALIDATION_STRINGENCY=LENIENT
  
- ```
- ### Rename fastqs based on naming scheme.
- ```
-             python3<<CODE
+```
+### Rename fastqs based on naming scheme.
  
-             import os
-             import ast
+```
+     python3<<CODE
  
-             rgData = ast.literal_eval("~{rgData}")
+     import os
+     import ast
  
-             f = "~{sep=' ' rawFastqs}"
-             fastqs = f.split()
+     rgData = ast.literal_eval("~{rgData}")
  
-             for fastq in fastqs:
-                 path = os.getcwd()
-                 fastqID = os.path.basename(fastq)[:-8] # determines ID
-                 readNum = int(fastq[-7]) # determines read number
-                 newName = rgData[fastqID][(readNum-1)]
-                 formattedFileName = f"{path}/{newName}"
-                 os.rename(fastq, formattedFileName)
-             
-             CODE
+     f = "~{sep=' ' rawFastqs}"
+     fastqs = f.split()
  
- ```
- ## Support
+     for fastq in fastqs:
+ 	path = os.getcwd()
+ 	fastqID = os.path.basename(fastq)[:-8] # determines ID
+ 	readNum = int(fastq[-7]) # determines read number
+ 	newName = rgData[fastqID][(readNum-1)]
+ 	formattedFileName = f"{path}/{newName}"
+ 	os.rename(fastq, formattedFileName)
+     
+     CODE
+ 
+     ls *.fastq.gz > outfilenames
+ 
+```
+ 
+### Copy out files if output directory specified
+ 
+```
+   set -euxo pipefail
+   if [[ -e ~{outputDir} && -d ~{outputDir} ]]; then
+     cp ~{Fastq} ~{outputDir}
+     echo "File ~{basename(Fastq)} copied to ~{outputDir}"
+   else
+     echo "Final Output Directory was not configured, ~{basename(Fastq)} was not provisioned properly"
+   fi
+```
+ 
+### Compose log file from messages produced by copy out shard
+ 
+```
+   python3 <<CODE
+   import json
+   import re
+   m_lines = re.split(",", "~{sep=',' messages}")
+   with open("copy_out.log", "w") as log:
+       for line in m_lines:
+ 	  log.write(line + "\n")
+   log.close()
+   CODE
+ 
+```
+## Support
 
 For support, please file an issue on the [Github project](https://github.com/oicr-gsi) or send an email to gsi@oicr.on.ca .
 

--- a/commands.txt
+++ b/commands.txt
@@ -1,4 +1,5 @@
 ## Commands
+
 This section lists command(s) run by bamToFastq workflow
 
 * Running bamToFastq
@@ -6,13 +7,15 @@ This section lists command(s) run by bamToFastq workflow
 bamToFastq generates R1 and R2 fastqs for BAM files with one or more readgroups.
 
 ### Pulling out readgroups and flag data from bam file
+
 ```
-            module load samtools
-            samtools flagstat ~{bamFile} > ~{prefix}.flagstat.txt
-            samtools view -H ~{bamFile} | grep -G "^@RG" > readgroups.tsv
+    module load samtools
+    samtools flagstat ~{bamFile} > ~{prefix}.flagstat.txt
+    samtools view -H ~{bamFile} | grep -G "^@RG" > readgroups.tsv
 ```
 
 ### Checking name validity and creating new filenames.
+
 By default, the fastqs are named using the read IDs. To use RG tags in the file names of the generated fastqs, input paramenter filNaming should be formatted like this:
 
 ```
@@ -25,8 +28,8 @@ By default, the fastqs are named using the read IDs. To use RG tags in the file 
 The file naming scheme will be declared invalid if:
 - It results in non-unique file names
 - It contains an invalid RG tag
-```
 
+```
         python3<<CODE
 
         import difflib
@@ -98,41 +101,68 @@ The file naming scheme will be declared invalid if:
 
 ```
 ### Backextract fastq files from bam file per readgroup.
-```
-            module unload cromwell ## <- only needed for local testing
-            module unload java ## <- only needed for local testing
-            module load picard
 
-            java -Xmx20g -jar $PICARD_ROOT/picard.jar SamToFastq \
-            INPUT=~{bamFile} \
-            RG_TAG="ID" \
-            OUTPUT_DIR=. \
-            OUTPUT_PER_RG=true \
-            NON_PF=true \
-            RE_REVERSE=true \
-            VALIDATION_STRINGENCY=LENIENT
+```
+    java -Xmx20g -jar $PICARD_ROOT/picard.jar SamToFastq \
+    INPUT=~{bamFile} \
+    RG_TAG="ID" \
+    OUTPUT_DIR=. \
+    OUTPUT_PER_RG=true \
+    NON_PF=true \
+    RE_REVERSE=true \
+    VALIDATION_STRINGENCY=LENIENT
 
 ```
 ### Rename fastqs based on naming scheme.
+
 ```
-            python3<<CODE
+    python3<<CODE
 
-            import os
-            import ast
+    import os
+    import ast
 
-            rgData = ast.literal_eval("~{rgData}")
+    rgData = ast.literal_eval("~{rgData}")
 
-            f = "~{sep=' ' rawFastqs}"
-            fastqs = f.split()
+    f = "~{sep=' ' rawFastqs}"
+    fastqs = f.split()
 
-            for fastq in fastqs:
-                path = os.getcwd()
-                fastqID = os.path.basename(fastq)[:-8] # determines ID
-                readNum = int(fastq[-7]) # determines read number
-                newName = rgData[fastqID][(readNum-1)]
-                formattedFileName = f"{path}/{newName}"
-                os.rename(fastq, formattedFileName)
-            
-            CODE
+    for fastq in fastqs:
+	path = os.getcwd()
+	fastqID = os.path.basename(fastq)[:-8] # determines ID
+	readNum = int(fastq[-7]) # determines read number
+	newName = rgData[fastqID][(readNum-1)]
+	formattedFileName = f"{path}/{newName}"
+	os.rename(fastq, formattedFileName)
+    
+    CODE
+
+    ls *.fastq.gz > outfilenames
+
+```
+
+### Copy out files if output directory specified
+
+```
+  set -euxo pipefail
+  if [[ -e ~{outputDir} && -d ~{outputDir} ]]; then
+    cp ~{Fastq} ~{outputDir}
+    echo "File ~{basename(Fastq)} copied to ~{outputDir}"
+  else
+    echo "Final Output Directory was not configured, ~{basename(Fastq)} was not provisioned properly"
+  fi
+```
+
+### Compose log file from messages produced by copy out shard
+
+```
+  python3 <<CODE
+  import json
+  import re
+  m_lines = re.split(",", "~{sep=',' messages}")
+  with open("copy_out.log", "w") as log:
+      for line in m_lines:
+	  log.write(line + "\n")
+  log.close()
+  CODE
 
 ```

--- a/tests/compare.sh
+++ b/tests/compare.sh
@@ -5,4 +5,4 @@ set -o errexit
 set -o pipefail
 
 #actual output metrics is $1, expected output metrics is $2
-diff $1 $2
+diff -bws $1 $2

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -2,15 +2,21 @@
   {
     "arguments": {
       "bamToFastq.nameCheck.timeout": null,
-      "bamToFastq.countFlags.modules": "samtools/0.1.19",
+      "bamToFastq.countFlags.modules": "samtools/1.14",
+      "bamToFastq.finalOutputDirectory": null,
       "bamToFastq.nameCheck.memory": null,
       "bamToFastq.backExtract.timeout": null,
       "bamToFastq.countFlags.memory": null,
       "bamToFastq.backExtract.memory": null,
-      "bamToFastq.renameFastqs.memory": null,
+      "bamToFastq.haveCustomDirRename.memory": null,
+      "bamToFastq.noCustomDirRename.memory": null,
       "bamToFastq.nameCheck.modules": null,
       "bamToFastq.countFlags.timeout": null,
       "bamToFastq.countFlags.prefix": null,
+      "bamToFastq.composeLog.memory": null,
+      "bamToFastq.composeLog.timeout": null,
+      "bamToFastq.copyOutFastq.memory": null,
+      "bamToFastq.copyOutFastq.timeout": null,
       "bamToFastq.backExtract.modules": "picard/2.21.2",
       "bamToFastq.bamFile": {
         "contents": {
@@ -24,9 +30,11 @@
         },
         "type": "EXTERNAL"
       },
-      "bamToFastq.renameFastqs.modules": null,
+      "bamToFastq.haveCustomDirRename.modules": null,
+      "bamToFastq.noCustomDirRename.modules": null,
       "bamToFastq.fileNaming": "{PU}_{PL}_test01",
-      "bamToFastq.renameFastqs.timeout": null
+      "bamToFastq.haveCustomDirRename.timeout": null,
+      "bamToFastq.noCustomDirRename.timeout": null
     },
     "description": "bamToFastq workflow test",
     "engineArguments": {
@@ -50,13 +58,21 @@
               }
           ],
           "type": "ALL"
+      },
+      "bamToFastq.copyLog": {
+          "contents": [
+              {
+                  "outputDirectory": "@SCRATCH@/@DATE@_Workflow_bamToFastqWorkflow_bamToFastq_dataset01_@JENKINSID@"
+              }
+          ],
+          "type": "ALL"
       }
     },
     "validators": [
       {
           "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
           "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-          "output_metrics": "/.mounts/labs/gsi/testdata/bamToFastq/output_metrics/1.0.0/bamToFastq_dataset01.metrics",
+          "output_metrics": "/.mounts/labs/gsi/testdata/bamToFastq/output_metrics/1.1.0/bamToFastq_dataset01.metrics",
           "type": "script"
       }
     ]
@@ -64,12 +80,96 @@
   {
     "arguments": {
       "bamToFastq.nameCheck.timeout": null,
-      "bamToFastq.countFlags.modules": "samtools/0.1.19",
+      "bamToFastq.countFlags.modules": "samtools/1.14",
+      "bamToFastq.finalOutputDirectory": "/.mounts/labs/gsi/testdata/bamToFastq/output",
       "bamToFastq.nameCheck.memory": null,
       "bamToFastq.backExtract.timeout": null,
       "bamToFastq.countFlags.memory": null,
       "bamToFastq.backExtract.memory": null,
-      "bamToFastq.renameFastqs.memory": null,
+      "bamToFastq.haveCustomDirRename.memory": null,
+      "bamToFastq.noCustomDirRename.memory": null,
+      "bamToFastq.nameCheck.modules": null,
+      "bamToFastq.countFlags.timeout": null,
+      "bamToFastq.countFlags.prefix": null,
+      "bamToFastq.composeLog.memory": null,
+      "bamToFastq.composeLog.timeout": null,
+      "bamToFastq.copyOutFastq.memory": null,
+      "bamToFastq.copyOutFastq.timeout": null,
+      "bamToFastq.backExtract.modules": "picard/2.21.2",
+      "bamToFastq.bamFile": {
+        "contents": {
+          "configuration": "/.mounts/labs/gsi/testdata/bamToFastq/inputs/HCCCFD_0183_Lv_P_PE_750_WG.merged.sorted.bam",
+          "externalIds": [
+            {
+              "id": "TEST",
+              "provider": "TEST"
+            }
+          ]
+        },
+        "type": "EXTERNAL"
+      },
+      "bamToFastq.haveCustomDirRename.modules": null,
+      "bamToFastq.noCustomDirRename.modules": null,
+      "bamToFastq.fileNaming": "{PU}_{PL}_test01",
+      "bamToFastq.haveCustomDirRename.timeout": null,
+      "bamToFastq.noCustomDirRename.timeout": null
+    },
+    "description": "bamToFastq workflow test with custom dir",
+    "engineArguments": {
+      "write_to_cache": false,
+      "read_from_cache": false
+    },
+    "id": "bamToFastq_dataset01m",
+    "metadata": {
+      "bamToFastq.flagStat": {
+          "contents": [
+              {
+                  "outputDirectory": "@SCRATCH@/@DATE@_Workflow_bamToFastqWorkflow_bamToFastq_dataset01m_@JENKINSID@"
+              }
+          ],
+          "type": "ALL"
+      },
+      "bamToFastq.modFastqs": {
+          "contents": [
+              {
+                  "outputDirectory": "@SCRATCH@/@DATE@_Workflow_bamToFastqWorkflow_bamToFastq_dataset01m_@JENKINSID@"
+              }
+          ],
+          "type": "ALL"
+      },
+      "bamToFastq.copyLog": {
+          "contents": [
+              {
+                  "outputDirectory": "@SCRATCH@/@DATE@_Workflow_bamToFastqWorkflow_bamToFastq_dataset01m_@JENKINSID@"
+              }
+          ],
+          "type": "ALL"
+      }
+    },
+    "validators": [
+      {
+          "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
+          "metrics_compare": "@CHECKOUT@/tests/compare.sh",
+          "output_metrics": "/.mounts/labs/gsi/testdata/bamToFastq/output_metrics/1.1.0/bamToFastq_dataset01m.metrics",
+          "type": "script"
+      }
+    ]
+  },
+  {
+    "arguments": {
+      "bamToFastq.nameCheck.timeout": null,
+      "bamToFastq.countFlags.modules": "samtools/1.14",
+      "bamToFastq.finalOutputDirectory": null,
+      "bamToFastq.nameCheck.memory": null,
+      "bamToFastq.backExtract.timeout": null,
+      "bamToFastq.countFlags.memory": null,
+      "bamToFastq.composeLog.memory": null,
+      "bamToFastq.composeLog.timeout": null,
+      "bamToFastq.copyOutFastq.memory": null,
+      "bamToFastq.copyOutFastq.timeout": null,
+      "bamToFastq.backExtract.memory": null,
+      "bamToFastq.haveCustomDirRename.memory": null,
+      "bamToFastq.noCustomDirRename.memory": null,
       "bamToFastq.nameCheck.modules": null,
       "bamToFastq.countFlags.timeout": null,
       "bamToFastq.countFlags.prefix": null,
@@ -86,9 +186,11 @@
         },
         "type": "EXTERNAL"
       },
-      "bamToFastq.renameFastqs.modules": null,
+      "bamToFastq.haveCustomDirRename.modules": null,
+      "bamToFastq.noCustomDirRename.modules": null,
       "bamToFastq.fileNaming": "{PU}_{PL}_test01",
-      "bamToFastq.renameFastqs.timeout": null
+      "bamToFastq.haveCustomDirRename.timeout": null,
+      "bamToFastq.noCustomDirRename.timeout": null
     },
     "description": "bamToFastq workflow test 2",
     "engineArguments": {
@@ -112,13 +214,21 @@
               }
           ],
           "type": "ALL"
+      },
+      "bamToFastq.copyLog": {
+          "contents": [
+              {
+                  "outputDirectory": "@SCRATCH@/@DATE@_Workflow_bamToFastqWorkflow_bamToFastq_dataset02_@JENKINSID@"
+              }
+          ],
+          "type": "ALL"
       }
     },
     "validators": [
       {
           "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
           "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-          "output_metrics": "/.mounts/labs/gsi/testdata/bamToFastq/output_metrics/1.0.0/bamToFastq_dataset02.metrics",
+          "output_metrics": "/.mounts/labs/gsi/testdata/bamToFastq/output_metrics/1.1.0/bamToFastq_dataset02.metrics",
           "type": "script"
       }
     ]


### PR DESCRIPTION
In this update we are adding a task which will copy output fastq files into an optionally specified directory, so there are two possible scenario possible now:

1. When **finalOutputDirectory** is not specified, everything goes as before, output fastq files and flagstat report are provisioned by cromwell according to its settings
2. However, if we specify **finalOutputDirectory** the workflow will not have fastq files as its outputs. Instead, it will copy the fastq files into **finalOutputDirectory** and produce a log saying where the files were copied to.